### PR TITLE
Fix notification typo

### DIFF
--- a/templates/media/mattermost/media_mattermost.yaml
+++ b/templates/media/mattermost/media_mattermost.yaml
@@ -499,7 +499,7 @@ zabbix_export:
             isShort
         ) {
             var message = {
-                fallbac: params.alert_subject,
+                fallback: params.alert_subject,
                 title: params.alert_subject,
                 color: event_severity_color,
                 title_link: problem_url,


### PR DESCRIPTION
Fix: typo falbac instead of fallback was preventing notification from displaying problem subject on mobile phones.